### PR TITLE
Add initial Makefile for build configuration and test management

### DIFF
--- a/Makefile_template_tu
+++ b/Makefile_template_tu
@@ -1,0 +1,75 @@
+#=== Toolchain ===#
+LLVM_DIR := /opt/homebrew/opt/llvm
+CXX := g++
+
+#=== Path flags ===#
+INCLUDE_DIRS := -Iinclude -Isrc -Iutil/tomlplusplus/include
+LIB_DIRS     := -L/usr/lib/gcc/x86_64-linux-gnu/11/
+
+#=== Feature flags ===#
+
+
+#=== External library flags ===#
+EXTERNAL_LIBS := hdf5
+
+#=== Aggregate final flags ===#
+CXXFLAGS := -std=c++17 -O3 -march=native -fopenmp $(INCLUDE_DIRS) \
+            $(shell pkg-config --cflags $(EXTERNAL_LIBS))
+LDFLAGS := $(LIB_DIRS) $(shell pkg-config --libs $(EXTERNAL_LIBS)) \
+           -L$(LLVM_DIR)/lib -Wl,-rpath,$(LLVM_DIR)/lib
+
+#=== File structure ===#
+CORE_DIR     := src/core
+MAIN_DIR     := src/main
+TEST_DIR    := test
+BUILD_DIR   := build
+
+#=== Searching all test/*.cpp ===#
+TESTS := $(basename $(notdir $(wildcard $(TEST_DIR)/*.cpp)))
+
+#=== Target of testfiles ===#
+TESTSTARGETS := $(addprefix $(BUILD_DIR)/test/, $(TESTS))
+
+#=== Target of setup.cpp ===#
+SETUPTARGET := setup
+SETUP_SRC   := $(MAIN_DIR)/setup.cpp $(wildcard $(CORE_DIR)/*.cpp)
+
+#=== Default make ===#
+all:
+	@echo "### Compiler        : $(CXX)"
+	@echo "### External libs   : $(EXTERNAL_LIBS)"
+	@echo "Tip: If your dependencies are not installed in system paths,"
+	@echo "        you may need to set:"
+	@echo "        export PKG_CONFIG_PATH=/your/custom/path/lib/pkgconfig"
+	@echo "Default build: main simulation target is not yet implemented."
+
+#=== Default Initial Condition constructor ===#
+setup:
+$(SETUPTARGET): $(SETUP_SRC)
+	@echo "### Compiler        : $(CXX)"
+	@echo "### External libs   : $(EXTERNAL_LIBS)"
+	@echo "Tip: If your dependencies are not installed in system paths,"
+	@echo "        you may need to set:"
+	@echo "        export PKG_CONFIG_PATH=/your/custom/path/lib/pkgconfig"
+	@echo "                   "
+	$(CXX) $(CXXFLAGS) $^ -o $@ $(LDFLAGS)
+
+#=== Compiling TestXXXXX.cpp to build/test/ ===#
+##=== General rule for specific test code folder to test/
+$(BUILD_DIR)/test/%: $(TEST_DIR)/%.cpp $(CORE_DIR)/*.cpp
+	@mkdir -p $(BUILD_DIR)/test
+	$(CXX) $(CXXFLAGS) $(filter %.cpp, $^) -o $@ $(LDFLAGS)
+##=== Compiling specific TestXXXXX.cpp ===##
+$(TESTS): %: $(BUILD_DIR)/test/%
+	@echo "Built $@"
+##=== Compiling all TestXXXXX.cpp to build/ ===##
+testall:
+	@echo "[Test Build] Building $(words $(TESTSTARGETS)) test programs..."
+	@$(MAKE) --no-print-directory $(TESTSTARGETS)
+	@echo "All tests built successfully!"
+
+#=== Clean all build ===#
+clean:
+	@find $(BUILD_DIR) -type f ! -name ".gitkeep" -delete
+	@find $(BUILD_DIR) -type d -empty -not -path "$(BUILD_DIR)" -delete
+	@echo "Cleaned build/"


### PR DESCRIPTION
This pull request introduces a new `Makefile_template_tu` file, which provides a structured and configurable build system for the project. The file defines compiler settings, paths, feature flags, external library integration, and build targets for setup and testing. It also includes utilities for cleaning the build directory.

### Key changes in `Makefile_template_tu`:

#### Build system configuration:
* Added definitions for the compiler (`CXX`), LLVM directory (`LLVM_DIR`), include directories (`INCLUDE_DIRS`), and library directories (`LIB_DIRS`) to centralize build settings.
* Introduced feature and external library flags (`CXXFLAGS`, `LDFLAGS`) to enable C++17, optimization, OpenMP, and external library integration via `pkg-config`.

#### File structure and targets:
* Defined key directories (`CORE_DIR`, `MAIN_DIR`, `TEST_DIR`, `BUILD_DIR`) and automated the detection of test files (`TESTS`).
* Added build targets for setup (`SETUPTARGET`) and individual test files, along with a `testall` target to compile all tests.

#### Utility commands:
* Implemented a `clean` target to remove build artifacts while preserving the `.gitkeep` file and maintaining the directory structure.