### PR TITLE
Kick & drift, and the direct Nbody calculation with OpenMP parallelization

### DIFF
--- a/Makefile.py
+++ b/Makefile.py
@@ -1,4 +1,3 @@
-### Generate by Chat GPT-o3
 #!/usr/bin/env python
 # build.py  --- Windows 取代 Makefile 的簡易 build script
 #

--- a/Makefile.py
+++ b/Makefile.py
@@ -1,0 +1,155 @@
+### Generate by Chat GPT-o3
+#!/usr/bin/env python
+# build.py  --- Windows 取代 Makefile 的簡易 build script
+#
+# 用法：
+#   python build.py                # same as “make simulation”
+#   python build.py simulation     # build simulation.exe
+#   python build.py setup          # build setup.exe
+#   python build.py testall        # build every test/*.cpp
+#   python build.py clean          # remove build artefacts
+#
+# 如要修改 HDF5 位置、編譯器或其他 flag，直接編輯下方常數即可。
+
+import sys
+import subprocess
+import os
+from pathlib import Path
+from shutil import rmtree
+from glob import glob
+import shlex
+
+# ──────────────────────────────────────────────────────────────
+# 🔧 1. 路徑與工具設定
+# ──────────────────────────────────────────────────────────────
+# 若你用的是 LLVM for Windows（例如 scoop / choco 裝的），通常只要把 clang++
+# 加進 PATH 即可；如果想強迫使用 LLVM 安裝資料夾，取消註解 LLVM_DIR 再下方用它。
+# LLVM_DIR = Path(r"C:\Program Files\LLVM")        # 例：LLVM 安裝根目錄
+CXX = r"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin\clang-cl.exe"                                     # or "g++", "cl"
+
+# HDF5 預設安裝路徑（請依自己的版本調整）
+HDF5_ROOT = Path(r"C:\Program Files\HDF_Group\HDF5\1.14.6")
+HDF5_INC  = HDF5_ROOT / "include"
+HDF5_LIB  = HDF5_ROOT / "lib"
+SZIP_ROOT = Path("E:/programming/libaec/build/src/Release")
+
+# 專案結構
+CORE_DIR  = Path("src/core")
+MAIN_DIR  = Path("src/main")
+TEST_DIR  = Path("test")
+BUILD_DIR = Path("build")
+(BUILD_DIR / "test").mkdir(parents=True, exist_ok=True)
+
+# ──────────────────────────────────────────────────────────────
+# 🔧 2. 編譯／連結旗標
+# ──────────────────────────────────────────────────────────────
+INCLUDE_DIRS = [
+    "/Iinclude",
+    "/Isrc",
+    "/Iutil/tomlplusplus/include",
+    f"/I{HDF5_INC}"
+]
+
+LIB_DIRS = [
+    f"/link",
+    "/machine:x64",
+    f"/LIBPATH:{HDF5_LIB}"
+]
+
+# ⚠️ Windows 不支援 -march=native 給 MSVC；若你改用 cl.exe 請刪掉。
+COMMON_CXXFLAGS = [
+    "/std:c++17",
+    "/O2",
+    "/MD",        # ✅ 配合 MSVC 預設 CRT（HDF5 預設用 /MD 編譯）
+    "/openmp",
+    "/EHsc",      # exception handler
+    "/bigobj",
+    "-DM_PI=3.14159265358979323846",
+]
+
+
+# 直接列絕對路徑，避免空白路徑被 linker 誤判
+LIBS = [
+    HDF5_LIB / "libhdf5_cpp.lib",
+    HDF5_LIB / "libhdf5.lib",
+    HDF5_LIB / "libhdf5_hl.lib",
+    HDF5_LIB / "zlib-static.lib",     
+    SZIP_ROOT / "aec-static.lib",
+    SZIP_ROOT / "szip-static.lib",
+    "shlwapi.lib",
+]
+LDFLAGS = [str(lib) for lib in LIBS]
+
+# ──────────────────────────────────────────────────────────────
+# 🔧 3. 公用函式
+# ──────────────────────────────────────────────────────────────
+def run(cmd: list[str]) -> None:
+    """執行編譯指令並在失敗時終止腳本。"""
+    print(">>", " ".join(shlex.quote(a) for a in cmd))
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+def compile_exe(output: Path, sources: list[Path]) -> None:
+    """將 sources 編譯成指定 exe。"""
+    cmd = [CXX, *COMMON_CXXFLAGS, *INCLUDE_DIRS,
+           *map(str, sources),
+           "-o", str(output),
+           *LIB_DIRS, *LDFLAGS]
+    run(cmd)
+
+# ──────────────────────────────────────────────────────────────
+# 🔧 4. 目標邏輯
+# ──────────────────────────────────────────────────────────────
+def target_simulation() -> None:
+    core = list(Path(CORE_DIR).glob("*.cpp"))
+    src  = [MAIN_DIR / "simulation.cpp", *core]
+    compile_exe("simulation.exe", src)
+
+def target_setup() -> None:
+    core = list(Path(CORE_DIR).glob("*.cpp"))
+    src  = [MAIN_DIR / "setup.cpp", *core]
+    compile_exe("setup.exe", src)
+
+def target_testall() -> None:
+    tests = sorted(Path(TEST_DIR).glob("*.cpp"))
+    if not tests:
+        print("No test/*.cpp found.")
+        return
+    print(f"[Test Build] Building {len(tests)} test programs …")
+    core = list(Path(CORE_DIR).glob("*.cpp"))
+    for tcpp in tests:
+        exe = BUILD_DIR / "test" / f"{tcpp.stem}.exe"
+        compile_exe(exe, [tcpp, *core])
+    print("All tests built successfully!")
+
+def target_clean() -> None:
+    if BUILD_DIR.exists():
+        for item in BUILD_DIR.iterdir():
+            if item.name == ".gitkeep":
+                continue
+            if item.is_dir():
+                rmtree(item)
+            else:
+                item.unlink()
+        print("Cleaned build/")
+    else:
+        print("Nothing to clean.")
+
+# ──────────────────────────────────────────────────────────────
+# 🔧 5. 主程式
+# ──────────────────────────────────────────────────────────────
+DEFAULT_TARGET = "simulation"
+TARGETS = {
+    "simulation": target_simulation,
+    "setup"     : target_setup,
+    "testall"   : target_testall,
+    "clean"     : target_clean,
+}
+
+if __name__ == "__main__":
+    tgt = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_TARGET
+    if tgt not in TARGETS:
+        print("Unknown target. Use one of:", ", ".join(TARGETS))
+        sys.exit(1)
+    TARGETS[tgt]()

--- a/Makefile.py
+++ b/Makefile.py
@@ -2,14 +2,13 @@
 #!/usr/bin/env python
 # build.py  --- Windows 取代 Makefile 的簡易 build script
 #
-# 用法：
+# Usage:
 #   python build.py                # same as “make simulation”
 #   python build.py simulation     # build simulation.exe
 #   python build.py setup          # build setup.exe
 #   python build.py testall        # build every test/*.cpp
 #   python build.py clean          # remove build artefacts
 #
-# 如要修改 HDF5 位置、編譯器或其他 flag，直接編輯下方常數即可。
 
 import sys
 import subprocess
@@ -20,20 +19,17 @@ from glob import glob
 import shlex
 
 # ──────────────────────────────────────────────────────────────
-# 🔧 1. 路徑與工具設定
+#       Path & Tool chain
 # ──────────────────────────────────────────────────────────────
-# 若你用的是 LLVM for Windows（例如 scoop / choco 裝的），通常只要把 clang++
-# 加進 PATH 即可；如果想強迫使用 LLVM 安裝資料夾，取消註解 LLVM_DIR 再下方用它。
-# LLVM_DIR = Path(r"C:\Program Files\LLVM")        # 例：LLVM 安裝根目錄
-CXX = r"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin\clang-cl.exe"                                     # or "g++", "cl"
+CXX = r"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin\clang-cl.exe"                        
 
-# HDF5 預設安裝路徑（請依自己的版本調整）
+# HDF5 Path
 HDF5_ROOT = Path(r"C:\Program Files\HDF_Group\HDF5\1.14.6")
 HDF5_INC  = HDF5_ROOT / "include"
 HDF5_LIB  = HDF5_ROOT / "lib"
 SZIP_ROOT = Path("E:/programming/libaec/build/src/Release")
 
-# 專案結構
+# Project Path
 CORE_DIR  = Path("src/core")
 MAIN_DIR  = Path("src/main")
 TEST_DIR  = Path("test")
@@ -41,7 +37,7 @@ BUILD_DIR = Path("build")
 (BUILD_DIR / "test").mkdir(parents=True, exist_ok=True)
 
 # ──────────────────────────────────────────────────────────────
-# 🔧 2. 編譯／連結旗標
+#       Flag of compiling
 # ──────────────────────────────────────────────────────────────
 INCLUDE_DIRS = [
     "/Iinclude",
@@ -56,19 +52,17 @@ LIB_DIRS = [
     f"/LIBPATH:{HDF5_LIB}"
 ]
 
-# ⚠️ Windows 不支援 -march=native 給 MSVC；若你改用 cl.exe 請刪掉。
 COMMON_CXXFLAGS = [
     "/std:c++17",
-    "/O2",
-    "/MD",        # ✅ 配合 MSVC 預設 CRT（HDF5 預設用 /MD 編譯）
+    "/Ox",
+    "/MD",        
     "/openmp",
-    "/EHsc",      # exception handler
+    "/EHsc",    
     "/bigobj",
     "-DM_PI=3.14159265358979323846",
 ]
 
 
-# 直接列絕對路徑，避免空白路徑被 linker 誤判
 LIBS = [
     HDF5_LIB / "libhdf5_cpp.lib",
     HDF5_LIB / "libhdf5.lib",
@@ -81,17 +75,17 @@ LIBS = [
 LDFLAGS = [str(lib) for lib in LIBS]
 
 # ──────────────────────────────────────────────────────────────
-# 🔧 3. 公用函式
+#       Common Method
 # ──────────────────────────────────────────────────────────────
 def run(cmd: list[str]) -> None:
-    """執行編譯指令並在失敗時終止腳本。"""
+    """Execute the compiling command"""
     print(">>", " ".join(shlex.quote(a) for a in cmd))
     result = subprocess.run(cmd)
     if result.returncode != 0:
         sys.exit(result.returncode)
 
 def compile_exe(output: Path, sources: list[Path]) -> None:
-    """將 sources 編譯成指定 exe。"""
+    """Compile program into .exe"""
     cmd = [CXX, *COMMON_CXXFLAGS, *INCLUDE_DIRS,
            *map(str, sources),
            "-o", str(output),
@@ -99,7 +93,7 @@ def compile_exe(output: Path, sources: list[Path]) -> None:
     run(cmd)
 
 # ──────────────────────────────────────────────────────────────
-# 🔧 4. 目標邏輯
+#           Target
 # ──────────────────────────────────────────────────────────────
 def target_simulation() -> None:
     core = list(Path(CORE_DIR).glob("*.cpp"))
@@ -137,7 +131,7 @@ def target_clean() -> None:
         print("Nothing to clean.")
 
 # ──────────────────────────────────────────────────────────────
-# 🔧 5. 主程式
+#       Main
 # ──────────────────────────────────────────────────────────────
 DEFAULT_TARGET = "simulation"
 TARGETS = {

--- a/include/ParticlesSetup.hpp
+++ b/include/ParticlesSetup.hpp
@@ -22,7 +22,8 @@ public:
     float udist = 3.08567758128e18;
     float umass = 1.989e33;
     // Other parameters
-    float softfactor = 0.02;
+    float softfactorx = 0.02;
+    float tsfactor = 0.2;
 
     // Destructor
     virtual ~ParticlesSetup() = default;
@@ -151,23 +152,12 @@ class ParticlesSetupIsotropic : public ParticlesSetup{
         float rcy = 0.0f;
         float rcz = 0.0f;
         // Range of r
-        float rmax = 1.0f;
+        float rmax = 5.0f;
         float alpha = -2.0f; // r-sampling with power law rho(r) ∝ r^alpha
-
-        // Range of vr
-        float vrmin = -1.0f;
-        float vrmax = 1.0f;
-        // Range of vphi
-        float vphimin = -1.0f;
-        float vphimax = 1.0f;
-        // Range of vtheta
-        float vthetamin = -1.0f;
-        float vthetamax = 1.0f;
-
     
         // Range of mass
-        float mmin = 1e-20f;
-        float mmax = 1.0f;
+        float mmin = 1e-3f;
+        float mmax = 1e-2f;
         
     
         // Constructor
@@ -197,30 +187,31 @@ class ParticlesSetupIsotropic : public ParticlesSetup{
             std::mt19937 rng(std::random_device{}());
 
             SamplingFunctionsSet sampler;
-            
-            // velocity sampler
-            std::uniform_real_distribution<float> distvr(vrmin, vrmax);
-            std::uniform_real_distribution<float> distvphi(vphimin, vphimax);
-            std::uniform_real_distribution<float> distvtheta(vthetamin, vthetamax);
 
             // rsampler
             std::uniform_real_distribution<float> urand(0.0f,1.0f);
             auto r_sampler = [=]() mutable {
                 float u = urand(rng);
-                float a = -1.0f; 
-                float exp = a + 3.0f;
+                float exp = alpha + 3.0f;
                 float norm = std::pow(rmax, exp) - std::pow(1e-3, exp);
                 return std::pow(u * norm + std::pow(1e-3, exp), 1.0f / exp);
             };
+
+            // Estimate sigma from mass & radius: sigma^2 ~ G M / R
+            float Mtot_estimate = 0.5f * (mmin + mmax) * static_cast<float>(N);
+            float sigma2 = (Mtot_estimate) / (rmax * 0.5f);            // assume R_eff = rmax / 2
+            float sigma = std::sqrt(sigma2);
+            std::normal_distribution<float> gauss_v(0.0f, sigma);
+
             auto xyz_sampler = [=]() mutable {
                 // sample position
                 float r = r_sampler();
                 float phi = 2.0f * M_PI * urand(rng);
                 float theta = std::acos(1.0f - 2.0f * urand(rng));  // sampling on cos(theta)
                 // sample velocity
-                float vr = distvr(rng);
-                float vphi = distvphi(rng);
-                float vtheta = distvtheta(rng);
+                float vr = gauss_v(rng);
+                float vphi = gauss_v(rng);
+                float vtheta = gauss_v(rng);
 
                 std::array<float, 6> sph_coor{};
                 sph_coor[0] = r;

--- a/include/ParticlesTable.hpp
+++ b/include/ParticlesTable.hpp
@@ -61,8 +61,6 @@ public:
         std::fill(_ax.begin(), _ax.end(), 0.0f);
         std::fill(_ay.begin(), _ay.end(), 0.0f);
         std::fill(_az.begin(), _az.end(), 0.0f);
-        
-        _generate_pidx2idx();
     }
     // Destructor
     ~ParticlesTable() = default;
@@ -142,26 +140,14 @@ public:
     void drift(float scale = 1.0);
 
     /*
-        bool is_active(uint32_t pindex);
+        void particles_validation();
         
-    Check whether the particle at `particle_index == pindex` is active (i.e., its smoothing length h >= 0).
+    Performs sanity checks and aggressive validation on particle data.
 
-    ## Input
-        - uint32_t pindex: Index of the particle in the particle table.
-
-    ## Output
-        - bool: `true` if the particle is active (h >= 0), `false` otherwise.
-    */
-    bool is_active(uint32_t pindex);
+    */        
+    void particles_validation();
 
 protected:
-
-    // Mapping for particles_index -> particles
-    std::unordered_map<uint32_t, size_t> _pidx2idx;
-    // generate the map
-    void _generate_pidx2idx();
-
-
     // Allocating vector
     virtual void _resize_vectors(std::size_t N) {
         particle_index.resize(N);

--- a/src/core/InitialConditionSetup.cpp
+++ b/src/core/InitialConditionSetup.cpp
@@ -20,7 +20,7 @@ ParticlesTable setup_initial_condition(const ParticlesSetup& setup, UnitsTable u
 
     // Sampling particles properties
     // Initialize h
-    float happrox = setup.softfactor * setup.simulation_scale * pow(pt.N, -1.0/3.0);
+    float happrox = setup.softfactorx * setup.simulation_scale * pow(pt.N, -1.0/3.0);
 
     float Mtot = 0;
     for (int i = 0; i < pt.N; ++i) {
@@ -44,7 +44,17 @@ ParticlesTable setup_initial_condition(const ParticlesSetup& setup, UnitsTable u
     }
     pt.Mtot = Mtot;
 
-    pt.calculate_dt();
+    // Initialize dt
+    float max_vel = 0.0f;
+    for (int i = 0; i < pt.N; ++i){
+        float vi = std::sqrt(pt.vx[i]*pt.vx[i] + pt.vy[i]*pt.vy[i] + pt.vz[i]*pt.vz[i]);
+        if (vi > max_vel) max_vel = vi;
+    }
+    float h_mean = mean(pt.h);
+    float dt_vel = setup.tsfactor * h_mean / std::max(max_vel, 1e-8f);
+    for (int i = 0; i < pt.N; ++i) {
+        pt.dt[i] = dt_vel;
+    }
 
     return pt;
 }

--- a/src/core/InitialConditionSetup.cpp
+++ b/src/core/InitialConditionSetup.cpp
@@ -19,6 +19,9 @@ ParticlesTable setup_initial_condition(const ParticlesSetup& setup, UnitsTable u
     pt.SimulationTag = setup.SimulationTag;
 
     // Sampling particles properties
+    // Initialize h
+    float happrox = setup.softfactor * setup.simulation_scale * pow(pt.N, -1.0/3.0);
+
     float Mtot = 0;
     for (int i = 0; i < pt.N; ++i) {
         pt.particle_index[i] = static_cast<uint32_t>(i + 1);
@@ -35,12 +38,12 @@ ParticlesTable setup_initial_condition(const ParticlesSetup& setup, UnitsTable u
 
         float mi = samplers.msampler();
         pt.m[i] = mi;
+        pt.h[i] = happrox;
         Mtot += mi;
 
     }
     pt.Mtot = Mtot;
 
-    pt.calculate_h();
     pt.calculate_dt();
 
     return pt;

--- a/src/core/ParticlesSetup.cpp
+++ b/src/core/ParticlesSetup.cpp
@@ -61,7 +61,8 @@ void ParticlesSetupUniform::_make_setupin_toml(const std::string& simulation_tag
     _write_toml_kvc(fout, "N", N, "Number of particles");
     _write_toml_kvc(fout, "udist", udist, "Code unit of length in cgs");
     _write_toml_kvc(fout, "umass", umass, "Code unit of mass in cgs");
-    _write_toml_kvc(fout, "softfactor", softfactor, "Softening factor for gravity (Suggestion: 0.01 < eta < 0.1)");
+    _write_toml_kvc(fout, "softfactorx", softfactorx, "Softening factor for gravity (Suggestion: 0.01 < etax < 0.1)");
+    _write_toml_kvc(fout, "tsfactor", tsfactor, "Factor for estimating timestep (Suggestion: 0.1 < etat < 1.0)");
     fout << "\n[InitialConditions]\n";
     fout << "# Initial Considion setup module: `Uniform` (Uniform box inside a given cube with given mass sampling range)\n";
     _write_toml_kvc(fout, "xmin", xmin, "Minimum x-position sampling for particles IN CODE UNITS.");
@@ -102,7 +103,8 @@ void ParticlesSetupUniform::_read_setupin_toml(const std::string& filename) {
     udist  = config["SimulationParameters"]["udist"].value_or(udist);
     umass  = config["SimulationParameters"]["umass"].value_or(umass);
     SimulationTag = config["SimulationParameters"]["SimulationTag"].value_or(SimulationTag);
-    softfactor  = config["SimulationParameters"]["softfactor"].value_or(softfactor);
+    softfactorx  = config["SimulationParameters"]["softfactorx"].value_or(softfactorx);
+    tsfactor  = config["SimulationParameters"]["tsfactor"].value_or(tsfactor);
 
     // ========= Initial Conditions =========
     xmin = config["InitialConditions"]["xmin"].value_or(xmin);
@@ -144,22 +146,16 @@ void ParticlesSetupIsotropic::_make_setupin_toml(const std::string& simulation_t
     _write_toml_kvc(fout, "N", N, "Number of particles");
     _write_toml_kvc(fout, "udist", udist, "Code unit of length in cgs");
     _write_toml_kvc(fout, "umass", umass, "Code unit of mass in cgs");
-    _write_toml_kvc(fout, "softfactor", softfactor, "Softening factor for gravity (Suggestion: 0.01 < eta < 0.1)");
+    _write_toml_kvc(fout, "softfactorx", softfactorx, "Softening factor for gravity (Suggestion: 0.01 < etax < 0.1)");
+    _write_toml_kvc(fout, "tsfactor", tsfactor, "Factor for estimating timestep (Suggestion: 0.1 < etat < 1.0)");
     fout << "\n[InitialConditions]\n";
     fout << "# Initial Considion setup module: `Isotropic` (Isotropic sphere with power law distribution along spacial direction.)\n";
     _write_toml_kvc(fout, "rmax", rmax, "Maximum radius for particles IN CODE UNITS.");
-    _write_toml_kvc(fout, "alpha", alpha, "Power law index r^-alpha");
+    _write_toml_kvc(fout, "alpha", alpha, "Power law index r^alpha");
 
     _write_toml_kvc(fout, "rcx", rcx, "x-position of center of particles distribution IN CODE UNITS.");
     _write_toml_kvc(fout, "rcy", rcy, "y-position of center of particles distribution IN CODE UNITS.");
     _write_toml_kvc(fout, "rcz", rcz, "z-position of center of particles distribution IN CODE UNITS.");
-
-    _write_toml_kvc(fout, "vrmin", vrmin, "Minimum vr-position sampling for particles IN CODE UNITS.");
-    _write_toml_kvc(fout, "vrmax", vrmax, "Maximum vr-position sampling for particles IN CODE UNITS.");
-    _write_toml_kvc(fout, "vphimin", vphimin, "Minimum vphi-position sampling for particles IN CODE UNITS.");
-    _write_toml_kvc(fout, "vphimax", vphimax, "Maximum vphi-position sampling for particles IN CODE UNITS.");
-    _write_toml_kvc(fout, "vthetamin", vthetamin, "Minimum vtheta-position sampling for particles IN CODE UNITS.");
-    _write_toml_kvc(fout, "vthetamax", vthetamax, "Maximum vtheta-position sampling for particles IN CODE UNITS.");
 
     _write_toml_kvc(fout, "mmin", mmin, "Minimum mass sampling for particles IN CODE UNITS.");
     _write_toml_kvc(fout, "mmax", mmax, "Maximum mass sampling for particles IN CODE UNITS.");
@@ -185,7 +181,8 @@ void ParticlesSetupIsotropic::_read_setupin_toml(const std::string& filename) {
     udist  = config["SimulationParameters"]["udist"].value_or(udist);
     umass  = config["SimulationParameters"]["umass"].value_or(umass);
     SimulationTag = config["SimulationParameters"]["SimulationTag"].value_or(SimulationTag);
-    softfactor  = config["SimulationParameters"]["softfactor"].value_or(softfactor);
+    softfactorx  = config["SimulationParameters"]["softfactorx"].value_or(softfactorx);
+    tsfactor  = config["SimulationParameters"]["tsfactor"].value_or(tsfactor);
 
     // ========= Initial Conditions =========
     rmax = config["InitialConditions"]["rmax"].value_or(rmax);
@@ -193,13 +190,6 @@ void ParticlesSetupIsotropic::_read_setupin_toml(const std::string& filename) {
     rcx = config["InitialConditions"]["rcx"].value_or(rcx);
     rcy = config["InitialConditions"]["rcy"].value_or(rcy);
     rcz = config["InitialConditions"]["rcz"].value_or(rcz);
-
-    vrmin = config["InitialConditions"]["vrmin"].value_or(vrmin);
-    vrmax = config["InitialConditions"]["vrmax"].value_or(vrmax);
-    vphimin = config["InitialConditions"]["vphimin"].value_or(vphimin);
-    vphimax = config["InitialConditions"]["vphimax"].value_or(vphimax);
-    vthetamin = config["InitialConditions"]["vthetamin"].value_or(vthetamin);
-    vthetamax = config["InitialConditions"]["vthetamax"].value_or(vthetamax);
 
     mmin = config["InitialConditions"]["mmin"].value_or(mmin);
     mmax = config["InitialConditions"]["mmax"].value_or(mmax);

--- a/src/core/ParticlesSetup.cpp
+++ b/src/core/ParticlesSetup.cpp
@@ -61,6 +61,7 @@ void ParticlesSetupUniform::_make_setupin_toml(const std::string& simulation_tag
     _write_toml_kvc(fout, "N", N, "Number of particles");
     _write_toml_kvc(fout, "udist", udist, "Code unit of length in cgs");
     _write_toml_kvc(fout, "umass", umass, "Code unit of mass in cgs");
+    _write_toml_kvc(fout, "softfactor", softfactor, "Softening factor for gravity (Suggestion: 0.01 < eta < 0.1)");
     fout << "\n[InitialConditions]\n";
     fout << "# Initial Considion setup module: `Uniform` (Uniform box inside a given cube with given mass sampling range)\n";
     _write_toml_kvc(fout, "xmin", xmin, "Minimum x-position sampling for particles IN CODE UNITS.");
@@ -101,6 +102,7 @@ void ParticlesSetupUniform::_read_setupin_toml(const std::string& filename) {
     udist  = config["SimulationParameters"]["udist"].value_or(udist);
     umass  = config["SimulationParameters"]["umass"].value_or(umass);
     SimulationTag = config["SimulationParameters"]["SimulationTag"].value_or(SimulationTag);
+    softfactor  = config["SimulationParameters"]["softfactor"].value_or(softfactor);
 
     // ========= Initial Conditions =========
     xmin = config["InitialConditions"]["xmin"].value_or(xmin);
@@ -119,6 +121,13 @@ void ParticlesSetupUniform::_read_setupin_toml(const std::string& filename) {
 
     mmin = config["InitialConditions"]["mmin"].value_or(mmin);
     mmax = config["InitialConditions"]["mmax"].value_or(mmax);
+
+    // ========= Other quantities =========
+    // Simulation scale
+    float dx = xmax - xmin;
+    float dy = ymax - ymin;
+    float dz = zmax - zmin;
+    simulation_scale = sqrtf(dx * dx + dy * dy + dz * dz);
 };
 
 // Case: ParticlesSetupIsotropic
@@ -135,6 +144,7 @@ void ParticlesSetupIsotropic::_make_setupin_toml(const std::string& simulation_t
     _write_toml_kvc(fout, "N", N, "Number of particles");
     _write_toml_kvc(fout, "udist", udist, "Code unit of length in cgs");
     _write_toml_kvc(fout, "umass", umass, "Code unit of mass in cgs");
+    _write_toml_kvc(fout, "softfactor", softfactor, "Softening factor for gravity (Suggestion: 0.01 < eta < 0.1)");
     fout << "\n[InitialConditions]\n";
     fout << "# Initial Considion setup module: `Isotropic` (Isotropic sphere with power law distribution along spacial direction.)\n";
     _write_toml_kvc(fout, "rmax", rmax, "Maximum radius for particles IN CODE UNITS.");
@@ -175,6 +185,7 @@ void ParticlesSetupIsotropic::_read_setupin_toml(const std::string& filename) {
     udist  = config["SimulationParameters"]["udist"].value_or(udist);
     umass  = config["SimulationParameters"]["umass"].value_or(umass);
     SimulationTag = config["SimulationParameters"]["SimulationTag"].value_or(SimulationTag);
+    softfactor  = config["SimulationParameters"]["softfactor"].value_or(softfactor);
 
     // ========= Initial Conditions =========
     rmax = config["InitialConditions"]["rmax"].value_or(rmax);
@@ -192,4 +203,8 @@ void ParticlesSetupIsotropic::_read_setupin_toml(const std::string& filename) {
 
     mmin = config["InitialConditions"]["mmin"].value_or(mmin);
     mmax = config["InitialConditions"]["mmax"].value_or(mmax);
+
+    // ========= Other quantities =========
+    // Simulation scale
+    simulation_scale = 2 * rmax;
 };

--- a/src/core/ParticlesTable.cpp
+++ b/src/core/ParticlesTable.cpp
@@ -209,9 +209,6 @@ void ParticlesTable::calculate_h(){
 
 void ParticlesTable::calculate_dt(){
     // NEED IMPLEMENT
-    for (int i = 0; i < N; ++i) {
-        dt[i] = 0.1;
-    }
 }
 
 void ParticlesTable::calculate_a_dirnbody(){

--- a/src/core/ParticlesTable.cpp
+++ b/src/core/ParticlesTable.cpp
@@ -205,9 +205,6 @@ ParticlesTable ParticlesTable::read_particles_table(const std::string& filename)
 
 void ParticlesTable::calculate_h(){
     // NEED IMPLEMENT
-    for (int i = 0; i < N; ++i) {
-        h[i] = 0.1;
-    }
 }
 
 void ParticlesTable::calculate_dt(){
@@ -218,7 +215,29 @@ void ParticlesTable::calculate_dt(){
 }
 
 void ParticlesTable::calculate_a_dirnbody(){
-    // NEED IMPLEMENT
+    // Direct calculate acc
+    #pragma omp parallel for 
+    for (int i = 0; i < N; ++i){
+        float axtemp = 0.0;
+        float aytemp = 0.0;
+        float aztemp = 0.0;
+        for (int j = 0; j < N; ++j){
+            if (i == j) continue;
+            float dx = x[j] - x[i];
+            float dy = y[j] - y[i];
+            float dz = z[j] - z[i];
+            float dr2 = dx * dx + dy * dy + dz * dz + h[i] * h[i];
+            float invr = 1.0f / sqrtf(dr2);
+            float invr3 = invr * invr * invr;
+            float mjinvr3 = m[j] * invr3;
+            axtemp += mjinvr3 * dx;
+            aytemp += mjinvr3 * dy;
+            aztemp += mjinvr3 * dz;
+        }
+        _ax[i] = axtemp;
+        _ay[i] = aytemp;
+        _az[i] = aztemp;
+    }
 }
 
 void ParticlesTable::calculate_a_BHtree(){

--- a/src/core/SimulationSetup.cpp
+++ b/src/core/SimulationSetup.cpp
@@ -56,8 +56,8 @@ void SimulationSetup::generate_parameters_file(const ParticlesSetup& setup, cons
     }
     fout << "[SimulationParameters]\n";
     _write_toml_kvc(fout, "input_file", input_file, "File for reading (Update whenever extract new dumpfile)");
-    _write_toml_kvc(fout, "tmax", 1.0e6 * dtref, "Max simulation time (IN CODE UNIT)");
-    _write_toml_kvc(fout, "dt_substepsmax", 1, " Max number of substeps per time step (Current No used)");
+    _write_toml_kvc(fout, "tmax", 4000.0 * dtref, "Max simulation time (IN CODE UNIT)");
+    _write_toml_kvc(fout, "dt_substepsmax", 1, "Max number of substeps per time step (Current No used)");
     _write_toml_kvc(fout, "num_per_dump", 10, "Dump output data per given timestep.");
     _write_toml_kvc(fout, "a_mode", 0, "Mode for calculate acceleration (0 => direct N-body, 1 => BHTree)");
 

--- a/src/main/setup.cpp
+++ b/src/main/setup.cpp
@@ -25,17 +25,23 @@ int main(int argc, char** argv){
     // Assign empty place for `ParticlesSetup`
     std::unique_ptr<ParticlesSetup> setupptr;
 
-    if (ICsetup == "uniform") {
-        std::cout << " Select Initial Condition mode: `uniform`\n";
-        std::cout << "     (Uniform box inside a given cube with given mass sampling range)\n\n";
-        setupptr = std::make_unique<ParticlesSetupUniform>(simulation_tag);
-    } else if (ICsetup == "isotropic") {
-        std::cout << " Select Initial Condition mode: `isotropic`\n";
-        std::cout << "     (Isotropic sphere with power law distribution along spacial direction.)\n\n";
-        setupptr = std::make_unique<ParticlesSetupIsotropic>(simulation_tag);
-    } else {
-        throw std::runtime_error("Unsupported setup mode: " + ICsetup);
+    try {
+        if (ICsetup == "uniform") {
+            std::cout << " Select Initial Condition mode: `uniform`\n";
+            std::cout << "     (Uniform box inside a given cube with given mass sampling range)\n\n";
+            setupptr = std::make_unique<ParticlesSetupUniform>(simulation_tag);
+        } else if (ICsetup == "isotropic") {
+            std::cout << " Select Initial Condition mode: `isotropic`\n";
+            std::cout << "     (Isotropic sphere with power law distribution along spacial direction.)\n\n";
+            setupptr = std::make_unique<ParticlesSetupIsotropic>(simulation_tag);
+        } else {
+            throw std::runtime_error("Unsupported setup mode: " + ICsetup);
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "Fatal error: " << e.what() << std::endl;
+        return 1;
     }
+    
     // Constructing `UnitsTable` from setup
     UnitsTable units = UnitsTable::setup_units(*setupptr);
 

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -77,11 +77,11 @@ int main(int argc, char** argv){
         float deltat = mean(pt.dt);         // Currently, we don't have hierarchial time stepping (DO NOT USE THIS IN HIERARCHIAL TIMESTEPPING!!!!!!!!)
         // Time add & output dumpfile
         std::cout 
-            << "t = " << std::fixed << std::setw(9) << std::setprecision(5) << pt.t
+            << "t = " << std::scientific << std::setw(13) << std::setprecision(6) << pt.t
             << " (code unit)  =====>  "
-            << std::fixed << std::setw(9) << std::setprecision(5) << pt.t + deltat
+            << std::scientific << std::setw(13) << std::setprecision(6) << pt.t + deltat
             << " (code unit), Walltime/iter = "
-            << std::setw(6) << duration << " us"
+            << std::setw(8) << duration << " us"
             << std::endl;
 
         pt.t += deltat;        

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -60,6 +60,9 @@ int main(int argc, char** argv){
         ptcalculate_a();
         pt.kick(0.5);
 
+        // Sanity check
+        pt.particles_validation();
+
         // Other updating
         float deltat = mean(pt.dt);         // Currently, we don't have hierarchial time stepping (DO NOT USE THIS IN HIERARCHIAL TIMESTEPPING!!!!!!!!)
         // Time add & output dumpfile

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -1,8 +1,10 @@
 #include <string>
 #include <iostream>
+#include <iomanip> 
 #include <toml++/toml.h>
 #include <omp.h>
 #include <functional>
+#include <chrono>
 #include "ParticlesSetup.hpp"
 #include "UnitsTable.hpp"
 #include "ParticlesTable.hpp"
@@ -25,6 +27,7 @@ int main(int argc, char** argv){
 
     // Setup parallel stuff (OpenMP and CUDA).
     omp_set_num_threads(simsetup.OMP_NUM_THREAD);
+    std::cout << "Assigning " << simsetup.OMP_NUM_THREAD << " threads to OpenMP." << std::endl;
 
     // Read current dump file
     int current_idt = simsetup.extract_current_index();
@@ -53,6 +56,9 @@ int main(int argc, char** argv){
         if (pt.t >= simsetup.tmax){
             break;
         }
+        // Timer start 
+        auto start = std::chrono::high_resolution_clock::now();
+
         // KDK algorithm
         ptcalculate_a();
         pt.kick(0.5);
@@ -63,12 +69,24 @@ int main(int argc, char** argv){
         // Sanity check
         pt.particles_validation();
 
+        // Timer end
+        auto end = std::chrono::high_resolution_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+
         // Other updating
         float deltat = mean(pt.dt);         // Currently, we don't have hierarchial time stepping (DO NOT USE THIS IN HIERARCHIAL TIMESTEPPING!!!!!!!!)
         // Time add & output dumpfile
-        std::cout << "t = " << pt.t << " (code unit)  =====>  " << pt.t + deltat << " (code unit)" << std::endl;
+        std::cout 
+            << "t = " << std::fixed << std::setw(9) << std::setprecision(5) << pt.t
+            << " (code unit)  =====>  "
+            << std::fixed << std::setw(9) << std::setprecision(5) << pt.t + deltat
+            << " (code unit), Walltime/iter = "
+            << std::setw(6) << duration << " us"
+            << std::endl;
+
         pt.t += deltat;        
         ++iter;
+        
         if (iter % simsetup.num_per_dump == 0){
             ++current_idt;
             std::string timeindex = format_index(current_idt, 5);

--- a/util/read_dumpfile.py
+++ b/util/read_dumpfile.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pandas as pd
+import h5py
+
+class ParticlesTable:
+    def __init__(self):
+        self.Table = None
+        self.params = {}
+
+    @staticmethod
+    def read_dumpfile(filepath):
+        obj = ParticlesTable()
+        with h5py.File(filepath, "r") as f:
+            # Table data
+            particle_index = f["Table/particle_index"][:]
+            x = f["Table/x"][:]
+            y = f["Table/y"][:]
+            z = f["Table/z"][:]
+            vx = f["Table/vx"][:]
+            vy = f["Table/vy"][:]
+            vz = f["Table/vz"][:]
+            m = f["Table/m"][:]
+            h = f["Table/h"][:]
+            dt = f["Table/dt"][:]
+            obj.Table = pd.DataFrame({
+                "particle_index": particle_index,
+                "x": np.float64(x),
+                "y": np.float64(y),
+                "z": np.float64(z),
+                "vx": np.float64(vx),
+                "vy": np.float64(vy),
+                "vz": np.float64(vz),
+                "m": np.float64(m),
+                "h": np.float64(h),
+                "dt": np.float64(dt),
+            })
+            # params data
+            param_group = f["params"]
+            for k in param_group.keys():
+                val = param_group[k][()]
+                obj.params[k] = val
+
+        return obj
+    
+    def transfer_cgs(self, year = True):
+        udist = np.float64(self.params["udist"])
+        umass = np.float64(self.params["umass"])
+        utime = np.float64(self.params["utime"])
+        uv = udist/utime
+
+        self.Table["x"] *= udist
+        self.Table["y"] *= udist
+        self.Table["z"] *= udist
+        self.Table["vx"] *= uv
+        self.Table["vy"] *= uv
+        self.Table["vz"] *= uv
+        self.Table["m"] *= umass
+        self.Table["h"] *= udist
+        self.Table["dt"] *= utime
+
+        self.params["Mtot"] *= umass
+        self.params["t"] *= utime
+        if year:
+            self.params["t"] /= 31556926 
+            self.Table["dt"] /= 31556926 
+


### PR DESCRIPTION
# Kick & Drift Integration and Direct N-body Acceleration (OpenMP)
This pull request introduces several major updates and improvements:

## Kick & Drift Scheme
The kick and drift method in `ParticlesTable` has been implemented. 

## Direct N-body acceleration calculator 
The direct N-body calculator for acceleration has been implemented. Note that this **might need a further validation**

## Removing functions `is_active()` and related method or attribute
AT. These attribute/Mehod has been removed because it is not that useful and slow.

## A simple python-based Makefile for Windows user
AT. 

## Add timer for simulation
AT.

## Modifying the `isotropic` setup
The velocity distribution of particle in isotropic setup are currently following Maxwell-Boltzmann distribution by comparing the Jeans condition.

## New format of output message for simulation
AT.

## A python-based dumpfile reader
AT. The python script is in `util` named `read_dumpfile.py`