### PR TITLE
Add GPU Support via CUDA, Improve Dumping Logic, and Update Build System

### DIFF
--- a/Makefile_templete
+++ b/Makefile_templete
@@ -1,5 +1,4 @@
 #=== Toolchain ===#
-LLVM_DIR := /opt/homebrew/opt/llvm
 CXX      := clang++
 
 #=== Path flags ===#

--- a/Makefile_templete_GPU
+++ b/Makefile_templete_GPU
@@ -1,5 +1,4 @@
 #=== Toolchain ===#
-LLVM_DIR := /opt/homebrew/opt/llvm
 CXX      := clang++
 CUDA_DIR    ?= /path/to/your/cuda
 NVCC        ?= $(CUDA_DIR)/bin/nvcc
@@ -12,7 +11,7 @@ LIB_DIRS     := -L/opt/homebrew/lib
 CUDA_FLAGS  := -arch=sm_60 -O3
 
 #=== Feature flags ===#
-
+USE_CUDA ?= 0
 
 #=== External library flags ===#
 EXTERNAL_LIBS := hdf5
@@ -30,12 +29,30 @@ BUILD_DIR   := build
 #=== Searching all test/*.cpp ===#
 TESTS := $(basename $(notdir $(wildcard $(TEST_DIR)/*.cpp)))
 
+#=== CUDA-related option ===#
+ifeq ($(USE_CUDA), 1)
+CXXFLAGS      += -DUSE_CUDA
+CUDA_OBJ_DIR  := $(BUILD_DIR)/gpu
+CUDA_SRC      =  $(wildcard src/gpu/*.cu)
+CUDA_OBJS     =  $(patsubst src/gpu/%.cu, $(CUDA_OBJ_DIR)/%.o, $(CUDA_SRC))
+LDFLAGS       += -L$(CUDA_DIR)/lib64 -lcudart
+
+# CUDA object build rule
+$(CUDA_OBJ_DIR)/%.o: src/gpu/%.cu
+	@mkdir -p $(CUDA_OBJ_DIR)
+	$(NVCC) -c $< -o $@ $(CUDA_FLAGS) -Iinclude -Isrc -Iutil/tomlplusplus/include
+endif
+
+
 #=== Target of testfiles ===#
 TESTSTARGETS := $(addprefix $(BUILD_DIR)/test/, $(TESTS))
 
 #=== Target of simulation.cpp ===#
 MAINTARGET := simulation
 MAIN_SRC   := $(MAIN_DIR)/simulation.cpp $(wildcard $(CORE_DIR)/*.cpp)
+ifeq ($(USE_CUDA), 1)
+MAIN_SRC += $(CUDA_OBJS)
+endif
 
 #=== Target of setup.cpp ===#
 SETUPTARGET := setup
@@ -46,13 +63,14 @@ simulation:
 $(MAINTARGET): $(MAIN_SRC)
 	@echo "### Compiler        : $(CXX)"
 	@echo "### External libs   : $(EXTERNAL_LIBS)"
+	@echo "### GPU Enabled     : $(USE_CUDA)"
 	@echo "Tip: If your dependencies are not installed in system paths,"
 	@echo "        you may need to set:"
 	@echo "        export PKG_CONFIG_PATH=/your/custom/path/lib/pkgconfig"
 	@echo "                   "
 	$(CXX) $(CXXFLAGS) $^ -o $@ $(LDFLAGS)
 
-#=== CUDA GPU Simulation === #
+
 
 #=== Default Initial Condition constructor ===#
 setup:

--- a/README.md
+++ b/README.md
@@ -1,84 +1,212 @@
 # ComputationalAstrophysicsFinal
-The final project of Computational Astrophysics course
+
+Final project for the **Computational Astrophysics** course in NTU (2025 spring)
+
+------
 
 ## Installation
-1. Downloding from this git
 
-2. Enter the `./ComputationalAstrophysicsFinal/` folder. Downloading the `tomlplusplus` library via
+1. Clone this repository:
 
-   ```bash
+   ~~~bash
+   git clone https://github.com/YOURUSERNAME/ComputationalAstrophysicsFinal.git
+   ~~~
+
+2. Enter the project directory:
+
+   ~~~bash
+   cd ComputationalAstrophysicsFinal
+   ~~~
+
+3. Download the `tomlplusplus` header-only library:
+
+   ~~~bash
    git clone https://github.com/marzer/tomlplusplus.git util/tomlplusplus 
-   ```
+   ~~~
 
-   
+------
 
 ## Usage
 
-### Initial Condition sampler
+### Makefile Support
 
-1. Compiling the setup file via
+All compilation processes are handled through `Makefile_templete`.
+ For **Windows** users, use the Python-based alternative `Makefile.py`.
 
-   ```bash
-   make setup
-   ```
+To configure your environment:
 
-   which will generate a `./setup` binary file in your current folder.
+- Set the correct path for the `CXX` compiler and update `LIB_DIRS` accordingly.
+- If using CUDA, ensure `CUDA_DIR` points to your CUDA installation.
 
-2. Executing `./setup` with specific parameter
+------
 
-   ```bash
-   ./setup setup_mode SIMULATIONTAG
-   ```
+3. - ### Initial Condition Sampler
 
-   The output initial condition file would be labeled in `SIMULATIONTAG_00000.h5`
+     1. **Compile the setup tool**
 
-   If `SIMULATIONTAG.setup` does not exist in current folder, a sample setup file correspond to given `setup_mode` would be generated automatically.
+        On **Unix/Linux/macOS**:
+   
+        ~~~bash
+        make setup
+        ~~~
+        
+        On **Windows**:
+        
+        ~~~powershell
+        python .\Makefile.py setup
+        ~~~
+   
+        This will generate an executable named `setup` (`setup.exe` on Windows).
+        
+     2. **Run the setup tool with mode and tag**
+     
+        On Unix/macOS:
+     
+        ~~~bash
+        ./setup setup_mode SIMULATIONTAG
+        ~~~
+        
+        On Windows (PowerShell or CMD):
+        
+        ~~~powershell
+        .\setup setup_mode SIMULATIONTAG
+        ~~~
+     
+        This creates an initial condition file named:
+        
+        ~~~bash
+        SIMULATIONTAG_00000.h5
+        ~~~
+        
+     3. **Automatic setup file generation**
+   
+        If `SIMULATIONTAG.setup` does not exist, a default version will be generated. You can then edit this file and rerun the command to regenerate the initial condition file.
+     
+        For example, to create a uniform box named `testuniform`:
+     
+        ~~~powershell
+        .\setup uniform testuniform
+        ~~~
+        
+        If `testuniform.setup` does not exist, it will be created.
+         Modify it as needed, then re-run the same command to produce:
+        
+        - `testuniform_00000.h5` — initial condition
+        - `testuniform.in` — simulation parameter file
 
-   For example, sampling a uniform box with `SIMULATIONTAG` = `testuniform`
+------
 
-   ```bash
-   ./setup uniform testuniform
-   ```
+### Main Simulation
 
-   Since `testuniform.setup` does not exist, it will generate a`testuniform.setup`.  After modifing the setup file, typing `./setup uniform testuniform` again, the initial condition file `testuniform_00000.h5` would be generated. Also, a parameter file `testuniform.in` will also been generated
+To compile the main simulation:
 
-### Main simulation suite
-
-The main loop of simulation is written inside `simulation.cpp`. To compile it, type in
-
-```bash
+~~~
 make
-```
+~~~
 
-in your terminal. To start the simulation, type in
+To enable CUDA compilation:
 
-```bash
+~~~bash
+make USE_CUDA=1
+~~~
+
+On **Windows**, use:
+
+~~~powershell
+python .\Makefile.py
+~~~
+
+To enable CUDA on Windows:
+
+~~~powershell
+python .\Makefile.py --gpu true
+~~~
+
+To run the simulation:
+
+~~~bash
 ./simulation YOURPARAMS.in
-```
+~~~
 
-Whenever a dumpfile is generated, the parameter file will update automatically.
+Each time a dump file is created, the parameter file is automatically updated.
 
-### Test code compiling suite
+> **Note:**
+>  GPU acceleration is only enabled if the `use_GPU` flag in `YOURPARAMS.in` is set to `true`.
+>  **Do not** set `use_GPU = true` if the program was not compiled with CUDA support.
 
-If you want to test your code, please put those source code into `./test` folder. For example, if you have a code named `TestHello.cpp` that would be tested. Move the `TestHello.cpp` into `./test`. Then type
+------
 
-``` bash
+### Test Suite
+
+To compile a single test file `TestHello.cpp` placed in the `./test` directory:
+
+~~~bash
 make TestHello
-```
+~~~
 
-The compiled binary would be generated with path:  `./build/test/TestHello`. 
+This creates:
 
-Or, if you wish to compile all the test files inside `./test`, just simply typing
+~~~bash
+./build/test/TestHello
+~~~
 
-```bash
+To compile **all** test files in `./test`:
+
+~~~bash
 make testall
-```
+~~~
 
-Then all of the source code inside `./test` would be compiled inside `./build/test/`. 
+To clean up all compiled files:
 
-If you want to clean all of the current compiled binaries. Entering
-
-```bash
+~~~bash
 make clean
-```
+~~~
 
+The Python-based replacement (`Makefile.py`) on Windows supports the same build targets and functionalities as the standard `Makefile` used on Unix-based systems.
+
+------
+
+### Julia-based 2D simulation visualization tool
+
+You can visualize the 2D simulation dumpfiles interactively using Julia.
+
+- **Unix/macOS users**:
+
+  ~~~
+  julia ./util/visualization_2Dparticles_interactive.jl Sim_00*.h5
+  ~~~
+
+  This command will load all matching dumpfiles in the current folder.
+
+- **Windows users**:
+
+  ~~~powershell
+  julia ./util/visualization_2Dparticles_interactive.jl PATH\TO\YOUR\RESULT\FOLDER
+  ~~~
+  
+  Replace `PATH\TO\YOUR\RESULT\FOLDER` with the folder path that contains the simulation dumpfiles. The script will automatically search for `.h5` files inside that folder.
+
+#### Julia Setup
+
+This script requires the following Julia packages:
+
+~~~julia
+import Pkg
+Pkg.add(["Makie", "GLMakie", "Observables", "GeometryBasics", "Statistics", "Glob", "Dates", "Printf", "HDF5
+~~~
+
+------
+
+### Read dumpfile
+
+The dumpfile reader is implemented in both **Python** and **Julia**, located in:
+
+- `util/read_dumpfile.py` (Python version, wrapped as a class)
+- `util/read_dumpfile.jl` (Julia version, implemented as a `struct`)
+
+Both versions provide consistent access to the following data fields:
+
+- `Table`: a table containing particle data with `Pandas`(Python)/`DataFrame`(Julia) (e.g., `x`, `y`, `vx`, `vy`, `m`, etc.)
+- `params`: a dictionary (or `Dict`) of global simulation parameters (e.g., `t`, `utime`, `SimulationTag`, `Utot`, etc.)
+
+The julia-based readers are used in interactive visualizations.

--- a/include/SimulationSetup.hpp
+++ b/include/SimulationSetup.hpp
@@ -23,6 +23,7 @@ public:
     int OMP_NUM_THREAD = 1;                                                 // Number of OpenMP threads                                
     
     // GPU setup
+    bool use_GPU = false;                                                   // Enable GPU
     int BLOCK_SIZE = 32;                                                    // GPU block size
 
 

--- a/src/core/Integrator.cpp
+++ b/src/core/Integrator.cpp
@@ -7,10 +7,35 @@ Integrator wrap_Integrator(ParticlesTable* pt, SimulationSetup* simsetup) {
     Integrator integrator;
     if (simsetup->a_mode == 0) {
         if (pt->dimension == 3) {
+            #ifdef USE_CUDA
+            if (simsetup->use_GPU){
+                integrator.calculate_a = [pt]() { pt->calculate_a_dirnbody_gpu(); };
+                integrator.kick        = [pt](float scale) { pt->kick_gpu(scale); };
+                integrator.drift       = [pt](float scale) { pt->drift_gpu(scale); };
+            } else {
+                integrator.calculate_a = [pt]() { pt->calculate_a_dirnbody(); };
+                integrator.kick        = [pt](float scale) { pt->kick(scale); };
+                integrator.drift       = [pt](float scale) { pt->drift(scale); };
+            }
+            return integrator;
+            #endif
             integrator.calculate_a = [pt]() { pt->calculate_a_dirnbody(); };
             integrator.kick        = [pt](float scale) { pt->kick(scale); };
             integrator.drift       = [pt](float scale) { pt->drift(scale); };
+            
         } else if (pt->dimension == 2) {
+            #ifdef USE_CUDA
+            if (simsetup->use_GPU){
+                integrator.calculate_a = [pt]() { pt->calculate_a_dirnbody_2D_gpu(); };
+                integrator.kick        = [pt](float scale) { pt->kick_2D_gpu(scale); };
+                integrator.drift       = [pt](float scale) { pt->drift_2D_gpu(scale); };
+            } else {
+                integrator.calculate_a = [pt]() { pt->calculate_a_dirnbody_2D(); };
+                integrator.kick        = [pt](float scale) { pt->kick(scale); };
+                integrator.drift       = [pt](float scale) { pt->drift(scale); };
+            }
+            return integrator;
+            #endif
             integrator.calculate_a = [pt]() { pt->calculate_a_dirnbody_2D(); };
             integrator.kick        = [pt](float scale) { pt->kick_2D(scale); };
             integrator.drift       = [pt](float scale) { pt->drift_2D(scale); };
@@ -20,10 +45,34 @@ Integrator wrap_Integrator(ParticlesTable* pt, SimulationSetup* simsetup) {
         }
     } else if (simsetup->a_mode == 1) {
         if (pt->dimension == 3) {
+            #ifdef USE_CUDA
+            if (simsetup->use_GPU){
+                integrator.calculate_a = [pt]() { pt->calculate_a_BHtree_gpu(); };
+                integrator.kick        = [pt](float scale) { pt->kick_gpu(scale); };
+                integrator.drift       = [pt](float scale) { pt->drift_gpu(scale); };
+            } else {
+                integrator.calculate_a = [pt]() { pt->calculate_a_BHtree(); };
+                integrator.kick        = [pt](float scale) { pt->kick(scale); };
+                integrator.drift       = [pt](float scale) { pt->drift(scale); };
+            }
+            return integrator;
+            #endif
             integrator.calculate_a = [pt]() { pt->calculate_a_BHtree(); };
             integrator.kick        = [pt](float scale) { pt->kick(scale); };
             integrator.drift       = [pt](float scale) { pt->drift(scale); };
         } else if (pt->dimension == 2) {
+            #ifdef USE_CUDA
+            if (simsetup->use_GPU){
+                integrator.calculate_a = [pt]() { pt->calculate_a_BHtree_2D_gpu(); };
+                integrator.kick        = [pt](float scale) { pt->kick_2D_gpu(scale); };
+                integrator.drift       = [pt](float scale) { pt->drift_2D_gpu(scale); };
+            } else {
+                integrator.calculate_a = [pt]() { pt->calculate_a_BHtree_2D(); };
+                integrator.kick        = [pt](float scale) { pt->kick(scale); };
+                integrator.drift       = [pt](float scale) { pt->drift(scale); };
+            }
+            return integrator;
+            #endif
             integrator.calculate_a = [pt]() { pt->calculate_a_BHtree_2D(); };
             integrator.kick        = [pt](float scale) { pt->kick_2D(scale); };
             integrator.drift       = [pt](float scale) { pt->drift_2D(scale); };

--- a/src/core/ParticlesTable.cpp
+++ b/src/core/ParticlesTable.cpp
@@ -8,6 +8,34 @@
 #include "QuadTree.hpp"
 #include "OctTree.hpp"
 
+ParticlesTable::ParticlesTable(const UnitsTable& unit, int N_)
+    : unittable(unit), N(N_)
+{
+    _resize_vectors(N);
+    std::fill(x.begin(), x.end(), 0.0f);
+    std::fill(y.begin(), y.end(), 0.0f);
+    std::fill(z.begin(), z.end(), 0.0f);
+    std::fill(vx.begin(), vx.end(), 0.0f);
+    std::fill(vy.begin(), vy.end(), 0.0f);
+    std::fill(vz.begin(), vz.end(), 0.0f);
+    std::fill(m.begin(),  m.end(),  0.0f);
+    std::fill(h.begin(),  h.end(),  0.0f);
+    std::fill(dt.begin(), dt.end(), 0.0f);
+    std::fill(_ax.begin(), _ax.end(), 0.0f);
+    std::fill(_ay.begin(), _ay.end(), 0.0f);
+    std::fill(_az.begin(), _az.end(), 0.0f);
+    std::fill(_U.begin(),  _U.end(),  0.0f);
+}
+
+void ParticlesTable::_resize_vectors(std::size_t N) {
+    particle_index.resize(N);
+    x.resize(N); y.resize(N); z.resize(N);
+    vx.resize(N); vy.resize(N); vz.resize(N);
+    m.resize(N); h.resize(N); dt.resize(N);
+    _ax.resize(N); _ay.resize(N); _az.resize(N);
+    _U.resize(N);
+}
+
 void ParticlesTable::_write_base_HDF5(hid_t file_id, bool debug) const {
     // ============== /params/ ==============
     hid_t g_params = H5Gcreate2(file_id, "/params", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);

--- a/src/core/SimulationSetup.cpp
+++ b/src/core/SimulationSetup.cpp
@@ -62,12 +62,13 @@ void SimulationSetup::generate_parameters_file(const ParticlesSetup& setup, cons
     _write_toml_kvc(fout, "dt_substepsmax", 1, "Max number of substeps per time step (Current No used)");
     _write_toml_kvc(fout, "num_per_dump", 10, "Dump output data per given timestep.");
     _write_toml_kvc(fout, "a_mode", 0, "Mode for calculate acceleration (0 => direct N-body, 1 => BHTree)");
-    _write_toml_kvc(fout, "print_internal", 0, "Dump internel vector in `ParticlesTable` (e.g. _ax, _ay, _az...) (0 => Don't print, 1 => print).");
+    _write_toml_kvc(fout, "print_internal", false, "Dump internel vector in `ParticlesTable` (e.g. _ax, _ay, _az...)");
 
     fout << "[CPUSetup]\n";
     _write_toml_kvc(fout, "OMP_NUM_THREAD", 1, "Number of OpenMP threads");
 
     fout << "[GPUSetup]\n";
+    _write_toml_kvc(fout, "use_GPU", false, "Enable GPU (Currently CUDA)");
     _write_toml_kvc(fout, "BLOCK_SIZE", 32, "GPU block size");
 
     fout << "\n";
@@ -81,7 +82,6 @@ void SimulationSetup::make_parameters_file(){
         std::cerr << "Failed to open file for writing: " << paramspath << std::endl;
         std::exit(1);
     }
-    int print_int = (print_internal) ? 1 : 0;
     fout << "[SimulationParameters]\n";
     _write_toml_kvc(fout, "input_file", input_file, "File for reading (Update whenever extract new dumpfile)");
     _write_toml_kvc(fout, "tmax", tmax, "Max simulation time (IN CODE UNIT)");
@@ -89,12 +89,13 @@ void SimulationSetup::make_parameters_file(){
     _write_toml_kvc(fout, "dt_substepsmax", dt_substepsmax, " Max number of substeps per time step (Current No used)");
     _write_toml_kvc(fout, "num_per_dump", num_per_dump, "Dump output data per given timestep.");
     _write_toml_kvc(fout, "a_mode", a_mode, "Mode for calculate acceleration (0 => direct N-body, 1 => BHTree)");
-    _write_toml_kvc(fout, "print_internal", print_int, "Dump internel vector in `ParticlesTable` (e.g. _ax, _ay, _az...) (0 => Don't print, 1 => print).");
+    _write_toml_kvc(fout, "print_internal", false, "Dump internel vector in `ParticlesTable` (e.g. _ax, _ay, _az...)");
 
     fout << "[CPUSetup]\n";
     _write_toml_kvc(fout, "OMP_NUM_THREAD", OMP_NUM_THREAD, "Number of OpenMP threads");
 
     fout << "[GPUSetup]\n";
+    _write_toml_kvc(fout, "use_GPU", use_GPU, "Enable GPU (Currently CUDA)");
     _write_toml_kvc(fout, "BLOCK_SIZE",BLOCK_SIZE, "GPU block size");
 
     fout << "\n";
@@ -116,15 +117,10 @@ void SimulationSetup::_read_params_toml(const std::string& paramsfilepath){
     dt_substepsmax           = config["SimulationParameters"]["dt_substepsmax"].value_or(dt_substepsmax);
     num_per_dump             = config["SimulationParameters"]["num_per_dump"].value_or(num_per_dump);
     a_mode                   = config["SimulationParameters"]["a_mode"].value_or(a_mode);
-    int print_int            = config["SimulationParameters"]["print_internal"].value_or(0);
+    print_internal            = config["SimulationParameters"]["print_internal"].value_or(print_internal);
     OMP_NUM_THREAD           = config["CPUSetup"]["OMP_NUM_THREAD"].value_or(OMP_NUM_THREAD);
+    use_GPU                  = config["GPUSetup"]["use_GPU"].value_or(use_GPU);
     BLOCK_SIZE               = config["GPUSetup"]["BLOCK_SIZE"].value_or(BLOCK_SIZE);
-
-    if (print_int == 0){
-        print_internal = false;
-    } else {
-        print_internal = true;
-    }
 
 }
 

--- a/src/gpu/ParticlesTable_gpu.cu
+++ b/src/gpu/ParticlesTable_gpu.cu
@@ -1,0 +1,523 @@
+#include "ParticlesTable.hpp"
+#include <cuda_runtime.h> 
+#include <cstdio>
+
+#define H2D cudaMemcpyHostToDevice
+#define D2H cudaMemcpyDeviceToHost
+
+#define CUDA_CHECK(call)                                                     \
+    do {                                                                     \
+        cudaError_t err = call;                                              \
+        if (err != cudaSuccess) {                                            \
+            fprintf(stderr, "CUDA error %s (%d) at %s:%d\n",                 \
+                    cudaGetErrorString(err), err, __FILE__, __LINE__);       \
+            std::abort();                                                    \
+        }                                                                    \
+    } while (0)
+
+// Device-only function
+// --- Direct N-body  ---
+__global__ void dirnbody_kernel(const float* __restrict x,
+                                const float* __restrict y,
+                                const float* __restrict z,
+                                const float* __restrict h,
+                                const float* __restrict m,
+                                float* __restrict ax,
+                                float* __restrict ay,
+                                float* __restrict az,
+                                float* __restrict U,
+                                int N)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= N) return;
+
+    float xi = x[i], yi = y[i], zi = z[i], hi = h[i];
+    float axt = 0.f, ayt = 0.f, azt = 0.f, Ut = 0.f;
+
+    for (int j = 0; j < N; ++j) {
+        if (i == j) continue;
+        float dx = x[j] - xi;
+        float dy = y[j] - yi;
+        float dz = z[j] - zi;
+        float dr2 = dx*dx + dy*dy + dz*dz + 0.5f*(hi*hi + h[j]*h[j]);
+        float invr = rsqrtf(dr2);       
+        float invr3 = invr * invr * invr;
+
+        float mjinvr3 = m[j] * invr3;
+        axt += mjinvr3 * dx;
+        ayt += mjinvr3 * dy;
+        azt += mjinvr3 * dz;
+        Ut  -= m[i] * m[j] * invr;
+    }
+    ax[i] = axt;  ay[i] = ayt;  az[i] = azt;  U[i] = Ut;
+}
+
+__global__ void dirnbody_2D_kernel(const float* __restrict x,
+                                const float* __restrict y,
+                                const float* __restrict h,
+                                const float* __restrict m,
+                                float* __restrict ax,
+                                float* __restrict ay,
+                                float* __restrict U,
+                                int N)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= N) return;
+
+    float xi = x[i], yi = y[i], hi = h[i];
+    float axt = 0.f, ayt = 0.f, Ut = 0.f;
+
+    for (int j = 0; j < N; ++j) {
+        if (i == j) continue;
+        float dx = x[j] - xi;
+        float dy = y[j] - yi;
+        float dr2 = dx*dx + dy*dy + 0.5f*(hi*hi + h[j]*h[j]);
+        float invr = rsqrtf(dr2);       
+        float invr3 = invr * invr * invr;
+
+        float mjinvr3 = m[j] * invr3;
+        axt += mjinvr3 * dx;
+        ayt += mjinvr3 * dy;
+        Ut  -= m[i] * m[j] * invr;
+    }
+    ax[i] = axt;  ay[i] = ayt;  U[i] = Ut;
+}
+
+// --- BH Tree ---
+__global__ void BHtree_kernel(const float* __restrict x,
+                                const float* __restrict y,
+                                const float* __restrict z,
+                                const float* __restrict h,
+                                const float* __restrict m,
+                                float* __restrict ax,
+                                float* __restrict ay,
+                                float* __restrict az,
+                                float* __restrict U,
+                                const OctNode* __restrict nodes,
+                                const int* __restrict order,
+                                int root_idx,
+                                float theta,
+                                int N)
+{
+    // Get idx
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= N) return;
+
+    // Construct a stack to mimic the recursion
+    const int MAX_STACK = 256;
+    int stack[MAX_STACK];
+    int sp = 0;                     // Current number of stack
+    stack[sp++] = root_idx;
+
+    // Get current quantities
+    float xi = x[idx];
+    float yi = y[idx];
+    float zi = z[idx];
+    float hi = h[idx];
+    float mi = m[idx];
+
+    float axi = 0.0f, ayi = 0.0f, azi = 0.0f, Ui = 0.0f;
+
+    while (sp > 0) {
+        int nidx = stack[--sp];  // Get node index
+        const OctNode& node = nodes[nidx];
+
+        if (node.pcount == 0) continue;
+
+        if (node.isLeaf()) {
+            for (int p = 0; p < node.pcount; ++p) {
+                int j = order[node.ParticlesLocateidx + p];
+                if (j == idx) continue;
+
+                float dx = x[j] - xi;
+                float dy = y[j] - yi;
+                float dz = z[j] - zi;
+                float r2 = dx*dx + dy*dy + dz*dz + 0.5f * (hi*hi + h[j]*h[j]);
+                float invr = rsqrtf(r2);
+                float invr3 = invr * invr * invr;
+                axi += m[j] * dx * invr3;
+                ayi += m[j] * dy * invr3;
+                azi += m[j] * dz * invr3;
+                Ui -= mi * m[j] * invr;
+            }
+            continue;
+        }
+
+        float dx = node.COMx - xi;
+        float dy = node.COMy - yi;
+        float dz = node.COMz - zi;
+        float r2 = dx*dx + dy*dy + dz*dz;
+
+        if (r2 > 1e-8f && node.cellsize() * rsqrtf(r2) < theta) {
+            r2 += hi*hi;
+            float invr = rsqrtf(r2);
+            float invr3 = invr * invr * invr;
+            float mInvr3 = node.Mtot * invr3;
+            axi += mInvr3 * dx;
+            ayi += mInvr3 * dy;
+            azi += mInvr3 * dz;
+            Ui -= mi * node.Mtot * invr;
+        } else {
+            for (int q = 0; q < 4; ++q) {
+                int cidx = node.children[q];
+                if (cidx >= 0 && sp < MAX_STACK){
+                    stack[sp++] = cidx;
+                }
+            }
+        }
+    }
+    // Store the acc into GPU array
+    ax[idx] = axi;
+    ay[idx] = ayi;
+    az[idx] = azi;
+    U[idx]  = Ui;
+}
+
+__global__ void BHtree_2D_kernel(const float* __restrict x,
+                                const float* __restrict y,
+                                const float* __restrict h,
+                                const float* __restrict m,
+                                float* __restrict ax,
+                                float* __restrict ay,
+                                float* __restrict U,
+                                const QuadNode* __restrict nodes,
+                                const int* __restrict order,
+                                int root_idx,
+                                float theta,
+                                int N)
+{
+    // Get idx
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= N) return;
+
+    // Construct a stack to mimic the recursion
+    const int MAX_STACK = 128;
+    int stack[MAX_STACK];
+    int sp = 0;                     // Current number of stack
+    stack[sp++] = root_idx;
+
+    // Get current quantities
+    float xi = x[idx];
+    float yi = y[idx];
+    float hi = h[idx];
+    float mi = m[idx];
+
+    float axi = 0.0f, ayi = 0.0f, Ui = 0.0f;
+
+    while (sp > 0) {
+        int nidx = stack[--sp];  // Get node index
+        const QuadNode& node = nodes[nidx];
+
+        if (node.pcount == 0) continue;
+
+        if (node.isLeaf()) {
+            for (int p = 0; p < node.pcount; ++p) {
+                int j = order[node.ParticlesLocateidx + p];
+                if (j == idx) continue;
+
+                float dx = x[j] - xi;
+                float dy = y[j] - yi;
+                float r2 = dx*dx + dy*dy + 0.5f * (hi*hi + h[j]*h[j]);
+                float invr = rsqrtf(r2);
+                float invr3 = invr * invr * invr;
+                axi += m[j] * dx * invr3;
+                ayi += m[j] * dy * invr3;
+                Ui -= mi * m[j] * invr;
+            }
+            continue;
+        }
+
+        float dx = node.COMx - xi;
+        float dy = node.COMy - yi;
+        float r2 = dx*dx + dy*dy;
+
+        if (r2 > 1e-8f && node.cellsize() * rsqrtf(r2) < theta) {
+            r2 += hi*hi;
+            float invr = rsqrtf(r2);
+            float invr3 = invr * invr * invr;
+            float mInvr3 = node.Mtot * invr3;
+            axi += mInvr3 * dx;
+            ayi += mInvr3 * dy;
+            Ui -= mi * node.Mtot * invr;
+        } else {
+            for (int q = 0; q < 4; ++q) {
+                int cidx = node.children[q];
+                if (cidx >= 0 && sp < MAX_STACK){
+                    stack[sp++] = cidx;
+                }
+            }
+        }
+    }
+    // Store the acc into GPU array
+    ax[idx] = axi;
+    ay[idx] = ayi;
+    U[idx]  = Ui;
+}
+
+
+
+// --- Kick ---
+__global__ void kick_kernel(float* __restrict vx,
+                            float* __restrict vy,
+                            float* __restrict vz,
+                            const float* __restrict ax,
+                            const float* __restrict ay,
+                            const float* __restrict az,
+                            const float* __restrict dt,
+                            float scale,
+                            int N)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= N) return;
+    float dt_i = dt[i];
+    float fac  = scale * dt_i;
+    vx[i] += fac * ax[i];
+    vy[i] += fac * ay[i];
+    vz[i] += fac * az[i];
+}
+
+__global__ void kick_2D_kernel( float* __restrict vx,
+                                float* __restrict vy,
+                                const float* __restrict ax,
+                                const float* __restrict ay,
+                                const float* __restrict dt,
+                                float scale,
+                                int N)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= N) return;
+    float dt_i = dt[i];
+    float fac  = scale * dt_i;
+    vx[i] += fac * ax[i];
+    vy[i] += fac * ay[i];
+}
+
+// --- Drift ---
+__global__ void drift_kernel(float* __restrict x,
+                             float* __restrict y,
+                             float* __restrict z,
+                             const float* __restrict vx,
+                             const float* __restrict vy,
+                             const float* __restrict vz,
+                             const float* __restrict dt,
+                             float scale,
+                             int N)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= N) return;
+    float dt_i = dt[i];
+    float fac  = scale * dt_i;
+    x[i] += fac * vx[i];
+    y[i] += fac * vy[i];
+    z[i] += fac * vz[i];
+}
+
+__global__ void drift_2D_kernel(float* __restrict x,
+                                float* __restrict y,
+                                const float* __restrict vx,
+                                const float* __restrict vy,
+                                const float* __restrict dt,
+                                float scale,
+                                int N)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= N) return;
+    float dt_i = dt[i];
+    float fac  = scale * dt_i;
+    x[i] += fac * vx[i];
+    y[i] += fac * vy[i];
+}
+
+
+
+
+// Method Definition
+void ParticlesTable::device_init() {
+    if (gpu_init) return;
+    size_t n = static_cast<size_t>(N) * sizeof(float);
+
+    CUDA_CHECK(cudaMalloc(&d_x , n)); CUDA_CHECK(cudaMalloc(&d_y , n)); CUDA_CHECK(cudaMalloc(&d_z , n));
+    CUDA_CHECK(cudaMalloc(&d_vx, n)); CUDA_CHECK(cudaMalloc(&d_vy, n)); CUDA_CHECK(cudaMalloc(&d_vz, n));
+    CUDA_CHECK(cudaMalloc(&d_m , n)); CUDA_CHECK(cudaMalloc(&d_h , n)); CUDA_CHECK(cudaMalloc(&d_dt, n));
+    CUDA_CHECK(cudaMalloc(&d_ax, n)); CUDA_CHECK(cudaMalloc(&d_ay, n)); CUDA_CHECK(cudaMalloc(&d_az, n));
+    CUDA_CHECK(cudaMalloc(&d_U , n));
+
+    upload_all();  
+    gpu_init = true;
+}
+
+void ParticlesTable::device_finalize() {
+    if (!gpu_init) return;
+    cudaFree(d_x);  cudaFree(d_y);  cudaFree(d_z);
+    cudaFree(d_vx); cudaFree(d_vy); cudaFree(d_vz);
+    cudaFree(d_m);  cudaFree(d_h); cudaFree(d_dt);
+    cudaFree(d_ax); cudaFree(d_ay); cudaFree(d_az); cudaFree(d_U);
+    cudaFree(d_nodes_2D); cudaFree(d_nodes_3D); cudaFree(d_order);
+    gpu_init = false;
+}
+
+void ParticlesTable::upload_all() {
+    size_t n=N*sizeof(float);
+    cudaMemcpyAsync(d_x , x.data() , n, H2D, stream);
+    cudaMemcpyAsync(d_y , y.data() , n, H2D, stream);
+    cudaMemcpyAsync(d_z , z.data() , n, H2D, stream);
+    cudaMemcpyAsync(d_vx, vx.data(), n, H2D, stream);
+    cudaMemcpyAsync(d_vy, vy.data(), n, H2D, stream);
+    cudaMemcpyAsync(d_vz, vz.data(), n, H2D, stream);
+    cudaMemcpyAsync(d_m , m.data() , n, H2D, stream);
+    cudaMemcpyAsync(d_h , h.data() , n, H2D, stream);
+    cudaMemcpyAsync(d_dt, dt.data(), n, H2D, stream);
+    cudaStreamSynchronize(stream);
+}
+
+void ParticlesTable::download_state() {           
+    size_t n=N*sizeof(float);
+    cudaMemcpyAsync(x.data() , d_x , n, D2H, stream);
+    cudaMemcpyAsync(y.data() , d_y , n, D2H, stream);
+    cudaMemcpyAsync(z.data() , d_z , n, D2H, stream);
+    cudaMemcpyAsync(vx.data(), d_vx, n, D2H, stream);
+    cudaMemcpyAsync(vy.data(), d_vy, n, D2H, stream);
+    cudaMemcpyAsync(vz.data(), d_vz, n, D2H, stream);
+    cudaMemcpyAsync(_ax.data(),d_ax, n, D2H, stream);
+    cudaMemcpyAsync(_ay.data(),d_ay, n, D2H, stream);
+    cudaMemcpyAsync(_az.data(),d_az, n, D2H, stream);
+    cudaMemcpyAsync(_U.data(), d_U,  n, D2H, stream);
+
+    cudaStreamSynchronize(stream);
+}
+
+void ParticlesTable::calculate_a_dirnbody_gpu() {
+    if (!gpu_init) device_init();
+    int grid = (N + block - 1) / block;
+    dirnbody_kernel<<<grid, block, 0, stream>>>(
+        d_x, d_y, d_z, d_h, d_m,
+        d_ax, d_ay, d_az, d_U, N);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+void ParticlesTable::calculate_a_dirnbody_2D_gpu() {
+    if (!gpu_init) device_init();
+    int grid = (N + block - 1) / block;
+    dirnbody_2D_kernel<<<grid, block, 0, stream>>>(
+        d_x, d_y, d_h, d_m,
+        d_ax, d_ay, d_U, N);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+void ParticlesTable::calculate_a_BHtree_gpu() {
+    // Prevent Tree recorvering
+    cudaStreamSynchronize(stream);
+    
+    // Build quadtree
+    OctTree tree = buildOctTree();
+
+    // Get root
+    const int root = tree.root_idx;
+
+    // Get theta
+    const float theta = tree.bhtheta;
+
+    // Preparing sending tree to GPU
+    int n_nodes = tree.nodes_list.size();
+    int n_order = tree.order.size();
+
+    // Allocate GPU
+    // Free pointer first
+    if (d_nodes_3D) cudaFree(d_nodes_3D);
+    if (d_order)    cudaFree(d_order);  
+    // Nodes
+    CUDA_CHECK(cudaMalloc(&d_nodes_3D , n_nodes * sizeof(OctNode)));
+    // Order
+    CUDA_CHECK(cudaMalloc(&d_order ,  n_order * sizeof(int)));
+
+    // Upload tree
+    cudaMemcpyAsync(d_nodes_3D , tree.nodes_list.data() ,  n_nodes * sizeof(OctNode), H2D, stream);
+    cudaMemcpyAsync(d_order , tree.order.data() ,  n_order * sizeof(int), H2D, stream);
+
+
+
+    if (!gpu_init) device_init();
+    int grid = (N + block - 1) / block;
+
+    BHtree_kernel<<<grid, block, 0, stream>>>(
+        d_x, d_y,  d_z, d_h, d_m,
+        d_ax, d_ay, d_az, d_U, d_nodes_3D, d_order,root, theta,  N);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+void ParticlesTable::calculate_a_BHtree_2D_gpu() {
+    // Prevent Tree recorvering
+    cudaStreamSynchronize(stream);
+
+    // Build quadtree
+    QuadTree tree = buildQuadTree();
+
+    // Get root
+    const int root = tree.root_idx;
+
+    // Get theta
+    const float theta = tree.bhtheta;
+
+    // Preparing sending tree to GPU
+    int n_nodes = tree.nodes_list.size();
+    int n_order = tree.order.size();
+
+    // Allocate GPU
+    // Free pointer first
+    if (d_nodes_2D) cudaFree(d_nodes_2D);
+    if (d_order)    cudaFree(d_order);  
+    // Nodes
+    CUDA_CHECK(cudaMalloc(&d_nodes_2D , n_nodes * sizeof(QuadNode)));
+    // Order
+    CUDA_CHECK(cudaMalloc(&d_order ,  n_order * sizeof(int)));
+
+    // Upload tree
+    cudaMemcpyAsync(d_nodes_2D , tree.nodes_list.data() ,  n_nodes * sizeof(QuadNode), H2D, stream);
+    cudaMemcpyAsync(d_order , tree.order.data() ,  n_order * sizeof(int), H2D, stream);
+
+
+
+    if (!gpu_init) device_init();
+    int grid = (N + block - 1) / block;
+
+    BHtree_2D_kernel<<<grid, block, 0, stream>>>(
+        d_x, d_y, d_h, d_m,
+        d_ax, d_ay, d_U, d_nodes_2D, d_order,root, theta,  N);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+void ParticlesTable::kick_gpu(float scale){
+    int grid = (N + block - 1) / block;
+    kick_kernel<<<grid, block, 0, stream>>>(
+        d_vx, d_vy, d_vz,
+        d_ax, d_ay, d_az,
+        d_dt, scale, N);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+void ParticlesTable::drift_gpu(float scale){
+    int grid = (N + block - 1) / block;
+    drift_kernel<<<grid, block, 0, stream>>>(
+        d_x, d_y, d_z,
+        d_vx, d_vy, d_vz,
+        d_dt, scale, N);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+void ParticlesTable::kick_2D_gpu(float scale){
+    int grid = (N + block - 1) / block;
+    kick_2D_kernel<<<grid, block, 0, stream>>>(
+        d_vx, d_vy,
+        d_ax, d_ay,
+        d_dt, scale, N);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+void ParticlesTable::drift_2D_gpu(float scale){
+    int grid = (N + block - 1) / block;
+    drift_2D_kernel<<<grid, block, 0, stream>>>(
+        d_x, d_y,
+        d_vx, d_vy,
+        d_dt, scale, N);
+    CUDA_CHECK(cudaGetLastError());
+}

--- a/src/main/setup.cpp
+++ b/src/main/setup.cpp
@@ -16,6 +16,8 @@ int main(int argc, char** argv){
     std::cout << "\n";
     std::cout << " Initial Condition Sampler\n";
     std::cout << "     Version 0.0.3\n";
+    std::cout << "      Main Developer: Wei-Shan Su,\n";
+    std::cout << "      Contributors:  Yu-Hsuan Tu, Yu-Jen Lin, (Conceptual discussion, physical modeling suggestions)";
 
     // Preparing input output argument
     std::string ICsetup = argv[1];

--- a/util/visualization_2Dparticles_interactive.jl
+++ b/util/visualization_2Dparticles_interactive.jl
@@ -4,7 +4,24 @@ using GLMakie
 using Observables
 using GeometryBasics
 using Statistics
+using Glob
+using Dates
 using Printf
+
+function get_files()
+    if Sys.iswindows()
+        if isempty(ARGS)
+            error("On Windows, please specify the folder containing HDF5 files as an argument.\nExample: julia visualization_2Dparticles_interactive.jl myfolder")
+        end
+        folder = ARGS[1]
+        return sort(glob("*.h5", folder)) 
+    else
+        if isempty(ARGS)
+            error("Please provide one or more HDF5 files as arguments.\nExample: julia visualization_2Dparticles_interactive.jl Sim_*.h5")
+        end
+        return ARGS
+    end
+end
 
 function main()
     # Two panel: The upper is the 2D visualization, the lower is the error-time diagram(fixed)
@@ -21,7 +38,7 @@ function main()
     title_obs = @lift($xytitle[3])
 
     # Read file
-    files = ARGS
+    files = get_files()
     testdata = read_dumpfile(files[1])
     SimulationTag[] = testdata.params["SimulationTag"]
 


### PR DESCRIPTION
Summary
This pull request introduces several major improvements to the project:

# GPU Acceleration
The simulation can now run on the GPU using CUDA. The force calculation supports both Direct N-body and Barnes–Hut Tree algorithms on GPU (2D and 3D).

# Initial Condition Re-Dumping
The program now automatically re-dumps the initial condition after computing the first acceleration and internal energy. This dump includes updated physics quantities 

# High-Resolution Timer
The timer now uses nanosecond resolution instead of microseconds. This change is necessary due to the high performance of GPU kernels, which may complete within a few microseconds.

# Cross-Platform GPU Build Support

The Makefile for Linux/macOS has been updated to support CUDA via USE_CUDA=1.

A Python-based Makefile.py is provided for Windows users, also supporting GPU compilation via --gpu true.

# README Updated
The README.md has been fully revised to reflect:

How to enable CUDA builds on all platforms

How to use the setup binary and simulation entrypoints

Visualization tools and how to run them on different systems

File structure and explanation of dumpfile readers (read_dumpfile.jl and .py)

# Affected Components
src/gpu/
GPU kernel implementations (*.cu) for both direct and tree-based methods

Makefile, Makefile.py
Updated to support GPU conditional build, object linking, and CUDA paths

src/main/simulation.cpp
Now supports post-initialization re-dump and updated timer resolution

README.md
Full revision with new build instructions, usage examples, and GPU notes